### PR TITLE
feat: move congratulations message to post_next_step_content job

### DIFF
--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -42,6 +42,22 @@ jobs:
           path: exercise-toolkit
           ref: v0.5.0
 
+      - name: Build message - step finished
+        id: build-message-step-finish
+        uses: skills/action-text-variables@v2
+        with:
+          template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
+          template-vars: |
+            next_step_number: 2
+
+      - name: Update comment - step finished
+        run: |
+          gh issue comment "$ISSUE_URL" \
+            --body "$ISSUE_BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
+          
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -97,22 +97,6 @@ jobs:
         if: contains(steps.*.outcome, 'failure')
         run: exit 1
 
-      - name: Build message - step finished
-        id: build-message-step-finish
-        uses: skills/action-text-variables@v2
-        with:
-          template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
-          template-vars: |
-            next_step_number: 2
-
-      - name: Update comment - step finished
-        run: |
-          gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
-
   post_review_content:
     name: Post review content
     needs: [find_exercise, check_step_work]


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

The post_next_step_content job has been updated to include the congratulations message (except for the first, start-exercise step)

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
