### PR TITLE
chore: bump all exercise-toolkit refs to v0.7.0, remove old `passed` statement

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -20,7 +20,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.6.0
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.7.0
     with:
       exercise-title: "(replace-me: Exercise title)"
       intro-message: "(replace-me: Brief one line introduction message for the exercise)"
@@ -42,7 +42,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.6.0
+          ref: v0.7.0
 
       - name: Create comment - add step content
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.6.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
 
   post_next_step_content:
     name: Post next step content
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.6.0
+          ref: v0.7.0
 
       - name: Create comment - step finished
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.6.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
 
   # This job is optional. We often call it a "grading job". If the step is not graded, remove it.
   check_step_work:
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.6.0
+          ref: v0.7.0
 
       - name: Find last comment
         id: find-last-comment
@@ -68,7 +68,7 @@ jobs:
       - name: Check if README file exists
         id: check-file-exists
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.6.0
+        uses: skills/exercise-toolkit/actions/file-exists@v0.7.0
         with:
           file: README.md
 
@@ -91,13 +91,12 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
           vars: |
             step_number: 2
-            passed: ${{ !contains(steps.*.outcome, 'failure') }}
             results_table:
               - description: "Checked if README.md file exists"
                 passed: ${{ steps.check-file-exists.outcome == 'success' }}
               - description: "Checked for Installation guide in README.md"
                 passed: ${{ steps.check-for-keyphrase.outcome == 'success' }}
-      
+
       # Add more checks as needed
 
       # END: Check practical exercise
@@ -123,7 +122,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.6.0
+          ref: v0.7.0
 
       - name: Create comment - step finished
         uses: GrantBirki/comment@v2.1.1

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
-    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.6.0
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.7.0
 
   post_review_content:
     name: Post review content
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.6.0
+          ref: v0.7.0
 
       - name: Create comment - step finished - final review next
         uses: GrantBirki/comment@v2.1.1
@@ -65,7 +65,7 @@ jobs:
   finish_exercise:
     name: Finish Exercise
     needs: [find_exercise, post_review_content]
-    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.6.0
+    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.7.0
     with:
       issue-url: ${{ needs.find_exercise.outputs.issue-url }}
       exercise-title: "(replace-me: Exercise title)"


### PR DESCRIPTION

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
This pull request updates the workflows in the repository to use the latest version (`v0.7.0`) of the `skills/exercise-toolkit` actions and workflows. Additionally, it includes minor adjustments to the logic for handling step results in one of the workflows.

### Workflow Updates:
* [`.github/workflows/0-start-exercise.yml`](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L23-R23): Updated `start-exercise.yml` and repository reference to use version `v0.7.0`. [[1]](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L23-R23) [[2]](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L45-R45)
* [`.github/workflows/1-step.yml`](diffhunk://#diff-6c6f5ac6d7d4f149a1e9ed5091f17d9cb9561291ffc92165ad87ed13ad440c0eL23-R23): Updated `find-exercise-issue.yml` and repository reference to use version `v0.7.0`. [[1]](diffhunk://#diff-6c6f5ac6d7d4f149a1e9ed5091f17d9cb9561291ffc92165ad87ed13ad440c0eL23-R23) [[2]](diffhunk://#diff-6c6f5ac6d7d4f149a1e9ed5091f17d9cb9561291ffc92165ad87ed13ad440c0eL42-R42)
* [`.github/workflows/2-step.yml`](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L26-R26): Updated `find-exercise-issue.yml`, repository reference, and `file-exists` action to use version `v0.7.0`. [[1]](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L26-R26) [[2]](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L46-R46) [[3]](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L71-R71) [[4]](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L126-R125)

### Logic Adjustments:
* [`.github/workflows/2-step.yml`](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L94): Removed unused `passed` variable from the step feedback logic.

### Final Step Updates:
* [`.github/workflows/3-last-step.yml`](diffhunk://#diff-cae1a4fb8ebcac8b62cc3b64a780c95a7154352c5393b0a3118e1382ab4d9e79L25-R25): Updated `find-exercise-issue.yml`, repository reference, and `finish-exercise.yml` to use version `v0.7.0`. [[1]](diffhunk://#diff-cae1a4fb8ebcac8b62cc3b64a780c95a7154352c5393b0a3118e1382ab4d9e79L25-R25) [[2]](diffhunk://#diff-cae1a4fb8ebcac8b62cc3b64a780c95a7154352c5393b0a3118e1382ab4d9e79L44-R44) [[3]](diffhunk://#diff-cae1a4fb8ebcac8b62cc3b64a780c95a7154352c5393b0a3118e1382ab4d9e79L68-R68)

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
